### PR TITLE
Reflect the default values in Settings.bundle in UserDefaults.

### DIFF
--- a/Examples/Example/Sources/AppDelegate.swift
+++ b/Examples/Example/Sources/AppDelegate.swift
@@ -18,6 +18,8 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool
     {
+        UserDefaults.standard.register(defaults: ["use_custom_drop_interaction": true])
+
         KeyboardGuide.shared.activate()
 
         // For Objective-C implementation, you can use `TwitterTextEditorBridgeConfiguration`.


### PR DESCRIPTION
**Problems**

In the current implementation, the value retrieved from UserDefaults is not True even if it appears True in Settings.app.

**Solution**

In this pull request, we give the Default Value of Settings.bundle as the Default Value of UserDefaults.

**Testing**

I tested this on my actual device iPad Pro.
