### PR TITLE
Add placeholderText in objc Examples

### DIFF
--- a/Examples/Example/Sources/ObjcViewController.m
+++ b/Examples/Example/Sources/ObjcViewController.m
@@ -86,6 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
     textEditorView.layer.borderWidth = 1.0;
 
     textEditorView.font = [UIFont systemFontOfSize:20.0];
+    textEditorView.placeholderText = @"This is an example of place holder text that can be truncated.";
 
     [self.view addSubview:textEditorView];
 

--- a/Examples/Example/Sources/TextEditorBridgeView.swift
+++ b/Examples/Example/Sources/TextEditorBridgeView.swift
@@ -80,6 +80,16 @@ final class TextEditorBridgeView: UIView {
             textEditorView.text = newValue
         }
     }
+    
+    @objc
+    var placeholderText: String? {
+        get {
+            textEditorView.placeholderText
+        }
+        set {
+            textEditorView.placeholderText = newValue
+        }
+    }
 
     @objc
     var scrollView: UIScrollView {


### PR DESCRIPTION
add placeholderText to allow at objc example

**Problems**
There is no placeholderText in Objc Example .

**Solution**
add placeholderText property at TextEditorBridgeView.

**Testing**
run Examples and check Objective-C example