### PR TITLE
Change Root.plist in Settings.bundle to have default value NO

### DIFF
--- a/Examples/Example/Resources/Settings.bundle/Root.plist
+++ b/Examples/Example/Resources/Settings.bundle/Root.plist
@@ -14,7 +14,7 @@
 			<key>Key</key>
 			<string>use_custom_drop_interaction</string>
 			<key>DefaultValue</key>
-			<true/>
+			<false/>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
**Problems**

In the current implementation, the value retrieved from UserDefaults is not True even if it appears True in Settings.app. 

**Solution**

I suggested this #3 . We discussed and decided that it would be simpler to set the default value to `NO`, so I changed the default value in Settings.bundle to `NO`.

**Testing**

I tested this on my actual device iPad Pro.
