### PR TITLE
Expose inputView and reloadInputViews method

### DIFF
--- a/Sources/TwitterTextEditor/TextEditorView.swift
+++ b/Sources/TwitterTextEditor/TextEditorView.swift
@@ -940,6 +940,7 @@ public final class TextEditorView: UIView {
         }
     }
     
+    /// :nodoc:
     public override func reloadInputViews() {
         textView.reloadInputViews()
     }

--- a/Sources/TwitterTextEditor/TextEditorView.swift
+++ b/Sources/TwitterTextEditor/TextEditorView.swift
@@ -929,6 +929,20 @@ public final class TextEditorView: UIView {
             _inputAccessoryViewController = newValue
         }
     }
+    
+    /// :nodoc:
+    public override var inputView: UIView? {
+        get {
+            textView.inputView
+        }
+        set {
+            textView.inputView = newValue
+        }
+    }
+    
+    public override func reloadInputViews() {
+        textView.reloadInputViews()
+    }
 
     /**
      The inset of the `textContentView`.


### PR DESCRIPTION
**Problems**

Due to the internal `UITextView` marked private. We can not access the `inputView` on it. 

**Solution**

Make an interface to expose the API. So that the client could use the `inputView` to customize input.

**Testing**
Delear an empty `UIInputView` and call the `reloadInputViews()`. It works.

``` swift
        let textEditorView = TextEditorView()
        let inputView = UIInputView(frame: CGRect(x: 0, y: 0, width: 0, height: 300), inputViewStyle: .keyboard)
        inputView.allowsSelfSizing = true
        textEditorView.inputView = inputView
        textEditorView.reloadInputViews()
```
<img src="https://user-images.githubusercontent.com/7940186/112417988-9b32ab80-8d63-11eb-80b7-a5588eabb31e.png" width=300 />
