### PR TITLE
Replace SwiftLint autocorrect command with `--fix`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,10 +81,10 @@ Use following command to execute linting.
 $ make lint
 ```
 
-Use following command to auto-correct linting problems.
+Use following command to fix linting problems.
 
 ```
-$ make correct
+$ make fix
 ```
 
 ### Documentation

--- a/Makefile
+++ b/Makefile
@@ -32,15 +32,15 @@ SWIFT = swift
 SWIFTLINT = swiftlint
 
 .PHONY: all
-all: correct test
+all: fix test
 
 .PHONY: clean
 clean:
 	git clean -dfX
 
-.PHONY: correct
-correct:
-	$(SWIFTLINT) autocorrect
+.PHONY: fix
+fix:
+	$(SWIFTLINT) --fix
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
**Problems**

Running `make correct` fails in the latest SwiftLint `v0.53.0` since SwiftLint `autocorrect` is [no longer available as of 0.43.0](https://github.com/realm/SwiftLint/issues/3571#issuecomment-799482027)

**Solution**

Replace `swiftlint autocorrect` with `swiftlint --fix`

**Testing**

Tested both `make all` and `make fix` works fine
